### PR TITLE
Update field.dart to fix bug when the field type is inferred and not explicitly set

### DIFF
--- a/flutter-ast/flutter_ast/lib/src/field.dart
+++ b/flutter-ast/flutter_ast/lib/src/field.dart
@@ -144,7 +144,9 @@ DartProperty _processProperty(FormalParameter node) {
 }
 
 DartField _process(VariableDeclarationListImpl node) {
-  late String _type, _name;
+  // bug fix when type is not set, this throws an exception for _type not being initialised
+  String? _type;
+  late String _name;
   for (final child in node.childEntities) {
     if (child is NamedTypeImpl) {
       final NamedTypeImpl _node = child;


### PR DESCRIPTION
final scaffoldKey = GlobalKey<ScaffoldState>();
The above example code gave a _type not initialised exception because the type is an inferred type. By making _type into String? _type, the problem is solved.